### PR TITLE
PULSE_548: Update `compile` script with new Grafana naming convention

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -19,10 +19,10 @@ export_env_dir() {
 
 echo "Download grafana agent binary..."
 mkdir -p $BUILD_DIR/bin
-curl -O -L --silent "https://github.com/grafana/agent/releases/latest/download/agent-linux-amd64.zip"
-unzip agent-linux-amd64.zip
-mv agent-linux-amd64 $BUILD_DIR/bin/grafana-agent
-rm agent-linux-amd64.zip
+curl -O -L --silent "https://github.com/grafana/agent/releases/download/latest/grafana-agent-linux-amd64.zip"
+unzip grafana-agent-linux-amd64.zip
+mv grafana-agent-linux-amd64 $BUILD_DIR/bin/grafana-agent
+rm grafana-agent-linux-amd64.zip
 
 echo "Grafana agent binary installed."
 


### PR DESCRIPTION
The binaries for the Grafana agent are now named "grafana-agent..." instead of just "agent..."

## What did you change?
🛠 Tech Debt
Update Grafana binary download to match new naming convention

## Why did you change it?
Heroku build is currently broken

## What should you test?
Check build logs in Heroku

