### PR TITLE
Update the compile script to use an older version of Grafana agent

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -19,10 +19,10 @@ export_env_dir() {
 
 echo "Download grafana agent binary..."
 mkdir -p $BUILD_DIR/bin
-curl -O -L --silent "https://github.com/grafana/agent/releases/download/latest/grafana-agent-linux-amd64.zip"
-unzip grafana-agent-linux-amd64.zip
-mv grafana-agent-linux-amd64 $BUILD_DIR/bin/grafana-agent
-rm grafana-agent-linux-amd64.zip
+curl -O -L --silent "https://github.com/grafana/agent/releases/download/v0.25.1/agent-linux-amd64.zip"
+unzip agent-linux-amd64.zip
+mv agent-linux-amd64 $BUILD_DIR/bin/grafana-agent
+rm agent-linux-amd64.zip
 
 echo "Grafana agent binary installed."
 


### PR DESCRIPTION
## What did you change?
🛠 Tech Debt

Lots has changed since this buildpack was last updated and the current goal is just to get it running again.


## Why did you change it?
Need to get the metrics review apps working in Heroku to test Stack upgrades

## What should you test?
Does the build succeed? Does the worker run without crashing?
